### PR TITLE
Make johnnydep compatible with Windows

### DIFF
--- a/johnnydep/lib.py
+++ b/johnnydep/lib.py
@@ -5,6 +5,7 @@ import errno
 import json
 import os
 import re
+import tempfile
 from collections import OrderedDict
 from collections import defaultdict
 from zipfile import ZipFile
@@ -234,7 +235,7 @@ class JohnnyDist(anytree.NodeMixin):
     @classmethod
     def tmp(cls):
         if getattr(cls, "_tmpdir", None) is None:
-            tmpdir = os.path.join((os.environ.get("TMPDIR") or "/tmp"), "johnnydep")
+            tmpdir = os.path.join(tempfile.gettempfile(), "johnnydep")
             logger.debug("get or create scratch", tmpdir=tmpdir)
             try:
                 os.mkdir(tmpdir)

--- a/johnnydep/lib.py
+++ b/johnnydep/lib.py
@@ -235,7 +235,8 @@ class JohnnyDist(anytree.NodeMixin):
     @classmethod
     def tmp(cls):
         if getattr(cls, "_tmpdir", None) is None:
-            tmpdir = os.path.join(tempfile.gettempfile(), "johnnydep")
+            tmpdir = os.environ.get("TMPDIR") or tempfile.gettempdir()
+            tmpdir = os.path.join(tmpdir, "johnnydep")
             logger.debug("get or create scratch", tmpdir=tmpdir)
             try:
                 os.mkdir(tmpdir)

--- a/tests/test_lib.py
+++ b/tests/test_lib.py
@@ -426,15 +426,17 @@ def test_env_data_converted_to_dict(make_dist):
 
 
 def test_pprint(make_dist, mocker):
+    mocker.patch("johnnydep.lib.id", return_value=3735928559)
     mock_printer = mocker.MagicMock()
     make_dist()
     jdist = JohnnyDist("jdtest")
     jdist._repr_pretty_(mock_printer, cycle=False)
-    pretty = '<JohnnyDist jdtest at 0x{:x}>'.format(id(jdist))
+    pretty = '<JohnnyDist jdtest at 0xdeadbeef>'
+    mock_printer.text.assert_called_once_with(pretty)
     mock_printer.text.reset_mock()
     jdist = JohnnyDist("jdtest[a]~=0.1.2")
     jdist._repr_pretty_(mock_printer, cycle=False)
-    pretty = '<JohnnyDist jdtest~=0.1.2[a] at 0x{:x}>'.format(id(jdist))
+    pretty = '<JohnnyDist jdtest~=0.1.2[a] at 0xdeadbeef>'
     mock_printer.text.assert_called_once_with(pretty)
     mock_printer.text.reset_mock()
     jdist._repr_pretty_(mock_printer, cycle=True)

--- a/tests/test_lib.py
+++ b/tests/test_lib.py
@@ -426,7 +426,7 @@ def test_env_data_converted_to_dict(make_dist):
 
 
 def test_pprint(make_dist, mocker):
-    mocker.patch("johnnydep.lib.id", return_value=3735928559)
+    mocker.patch("johnnydep.lib.id", return_value=3735928559, create=True)
     mock_printer = mocker.MagicMock()
     make_dist()
     jdist = JohnnyDist("jdtest")


### PR DESCRIPTION
The previous method was using linuxy paths, ie: `/tmp\\johnnydep`
This will use the tempfile module supplied by python to get a cross-platform temp file directory