### PR TITLE
Allow spaces in rootdir when running tests

### DIFF
--- a/johnnydep/compat.py
+++ b/johnnydep/compat.py
@@ -8,6 +8,12 @@ except ImportError:
     from urllib import urlretrieve
 
 try:
+    from urllib.parse import quote
+except ImportError:
+    # Python 2
+    from urllib import quote
+
+try:
     from json import JSONDecodeError
 except ImportError:
     # Python 2

--- a/tests/test_gen.py
+++ b/tests/test_gen.py
@@ -2,10 +2,10 @@
 from __future__ import unicode_literals
 
 import os
-import urllib
 
 import pytest
 
+from johnnydep.compat import quote
 from johnnydep.lib import JohnnyDist
 
 
@@ -68,7 +68,7 @@ def test_build_from_sdist(add_to_index):
     assert dist.extras_available == []
     assert dist.extras_requested == []
     assert dist.project_name == "copyingmock"
-    assert dist.download_link == "file://{}".format(urllib.parse.quote(sdist_fname))
+    assert dist.download_link == "file://{}".format(quote(sdist_fname))
     assert dist.checksum == "md5=9aa6ba13542d25e527fe358d53cdaf3b"
 
 

--- a/tests/test_gen.py
+++ b/tests/test_gen.py
@@ -2,6 +2,7 @@
 from __future__ import unicode_literals
 
 import os
+import urllib
 
 import pytest
 
@@ -67,7 +68,7 @@ def test_build_from_sdist(add_to_index):
     assert dist.extras_available == []
     assert dist.extras_requested == []
     assert dist.project_name == "copyingmock"
-    assert dist.download_link == "file://{}".format(sdist_fname)
+    assert dist.download_link == "file://{}".format(urllib.parse.quote(sdist_fname))
     assert dist.checksum == "md5=9aa6ba13542d25e527fe358d53cdaf3b"
 
 


### PR DESCRIPTION
Small change to allow tests to pass when run from a directory that has spaces in the path.

Because I'm running from Ubuntu under Windows (WSL), my home directory is `/mnt/c/Users/Wimberly Hugh` and so when I try to run the project tests I run into the test failure:
```
add_to_index = <function add_to_index.<locals>.add_package at 0x7f1edda07158>

    def test_build_from_sdist(add_to_index):
        sdist_fname = os.path.join(here, "copyingmock-0.2.tar.gz")
        fragment = "#md5=9aa6ba13542d25e527fe358d53cdaf3b"
        add_to_index(name="copyingmock", path=sdist_fname, urlfragment=fragment)
        dist = JohnnyDist("copyingmock")
        assert dist.name == "copyingmock"
        assert dist.summary == "A subclass of MagicMock that copies the arguments"
        assert dist.required_by == []
        assert dist.import_names == ["copyingmock"]
        assert dist.homepage == "https://github.com/wimglenn/copyingmock"
        assert dist.extras_available == []
        assert dist.extras_requested == []
        assert dist.project_name == "copyingmock"
>       assert dist.download_link == "file://{}".format(sdist_fname)
E       AssertionError: assert 'file:///mnt/...ck-0.2.tar.gz' == 'file:///mnt/c...ck-0.2.tar.gz'
E         - file:///mnt/c/Users/Wimberly%20Hugh/git_repos/johnnydep/tests/copyingmock-0.2.tar.gz
E         ?                             ^^^
E         + file:///mnt/c/Users/Wimberly Hugh/git_repos/johnnydep/tests/copyingmock-0.2.tar.gz
E         ?                             ^

tests/test_gen.py:71: AssertionError
```