### PR TITLE
change from pytoml to toml

### DIFF
--- a/johnnydep/__init__.py
+++ b/johnnydep/__init__.py
@@ -1,3 +1,3 @@
 """Display dependency tree of Python distribution"""
 
-__version__ = "1.4"
+__version__ = "1.5"

--- a/johnnydep/lib.py
+++ b/johnnydep/lib.py
@@ -14,7 +14,7 @@ import anytree
 import distlib.wheel
 import pkg_resources
 import pkginfo
-import pytoml
+import toml
 import tabulate
 import wimpy
 from cachetools.func import ttl_cache
@@ -236,7 +236,7 @@ class JohnnyDist(anytree.NodeMixin):
         elif format == "yaml":
             result = oyaml.dump(data)
         elif format == "toml":
-            result = "\n".join([pytoml.dumps(d) for d in data])
+            result = "\n".join([toml.dumps(d) for d in data])
         elif format == "pinned":
             result = "\n".join([d["pinned"] for d in data])
         else:

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
         "cachetools",
         "distlib",
         "oyaml",
-        "pytoml",
+        "toml",
         "pip",
         "packaging >= 17",
         "wheel >= 0.32.0",

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name="johnnydep",
-    version="1.4",
+    version="1.5",
     description="Display dependency tree of Python distribution",
     long_description=open("README.md").read(),
     long_description_content_type='text/markdown',

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -144,12 +144,12 @@ def test_all_fields_toml_out(mocker, capsys, make_dist):
         specifier = "<0.4"
         requires = []
         required_by = []
-        import_names = ["that"]
+        import_names = [ "that",]
         homepage = "https://www.example.org/default"
         extras_available = []
         extras_requested = []
         project_name = "wimpy"
-        versions_available = ["0.3"]
+        versions_available = [ "0.3",]
         version_installed = "0.3"
         version_latest = "0.3"
         version_latest_in_spec = "0.3"


### PR DESCRIPTION
> The pytoml project is no longer being actively maintained. Consider using the toml package instead.

Source: https://pypi.org/project/pytoml/