### PR TITLE
make it work with circular dep trees. closes #98. closes #23.

### DIFF
--- a/johnnydep/__init__.py
+++ b/johnnydep/__init__.py
@@ -1,5 +1,5 @@
 """Display dependency tree of Python distribution"""
 
-__version__ = "1.15"
+__version__ = "1.16"
 
 from johnnydep.lib import *

--- a/johnnydep/util.py
+++ b/johnnydep/util.py
@@ -1,7 +1,12 @@
+# coding: utf-8
+from __future__ import unicode_literals
+
 import json
 from argparse import ArgumentTypeError
 from subprocess import check_output
 from subprocess import CalledProcessError
+
+import anytree
 
 from johnnydep import env_check
 from johnnydep.compat import JSONDecodeError
@@ -18,3 +23,29 @@ def python_interpreter(path):
         raise ArgumentTypeError("Invalid python env output")
     frozen = tuple(map(tuple, env))
     return frozen
+
+
+class CircularMarker(anytree.NodeMixin):
+    """
+    This is like a "fake" JohnnyDist instance which is used
+    to render a node in circular dep trees like:
+
+    a
+    └── b
+        └── c
+            └── ...
+
+    Everything is null except the req/name which is "..." and
+    the metadata summary, which can be provided by the caller
+    """
+    glyph = "..."
+
+    def __init__(self, summary, parent):
+        self.req = CircularMarker.glyph
+        self.name = CircularMarker.glyph
+        self.summary = summary
+        self.parent = parent
+
+    def __getattr__(self, name):
+        if name.startswith("_"):
+            return super(CircularMarker, self).__getattr__(self, name)

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name="johnnydep",
-    version="1.15",
+    version="1.16",
     description="Display dependency tree of Python distribution",
     long_description=open("README.md").read(),
     long_description_content_type="text/markdown",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -211,3 +211,26 @@ def test_no_deps(mocker, capsys, make_dist):
         ------
         distA
     """)
+
+
+def test_circular_deptree(mocker, capsys, make_dist):
+    make_dist(name="pkg0", install_requires=["pkg1"], version="0.1")
+    make_dist(name="pkg1", install_requires=["pkg2", "quux"], version="0.2")
+    make_dist(name="pkg2", install_requires=["pkg3"], version="0.3")
+    make_dist(name="pkg3", install_requires=["pkg1"], version="0.4")
+    make_dist(name="quux")
+    mocker.patch("sys.argv", "johnnydep pkg0".split())
+    main()
+    out, err = capsys.readouterr()
+    assert out == dedent(
+        """\
+        name                     summary
+        -----------------------  -----------------------------------------------------------------
+        pkg0                     default text for metadata summary
+        └── pkg1                 default text for metadata summary
+            ├── pkg2             default text for metadata summary
+            │   └── pkg3         default text for metadata summary
+            │       └── pkg1     default text for metadata summary
+            │           └── ...  ... <circular dependency marker for pkg1 -> pkg2 -> pkg3 -> pkg1>
+            └── quux             default text for metadata summary
+    """)

--- a/tests/test_lib.py
+++ b/tests/test_lib.py
@@ -416,7 +416,7 @@ def test_pprint(make_dist, mocker):
     mock_printer.text.reset_mock()
     jdist = JohnnyDist("jdtest[a]~=0.1.2")
     jdist._repr_pretty_(mock_printer, cycle=False)
-    pretty = "<JohnnyDist jdtest~=0.1.2[a] at 0xcafe>"
+    pretty = "<JohnnyDist jdtest[a]~=0.1.2 at 0xcafe>"
     mock_printer.text.assert_called_once_with(pretty)
     mock_printer.text.reset_mock()
     jdist._repr_pretty_(mock_printer, cycle=True)


### PR DESCRIPTION
The output will look like this, rendering a "..." glyph to indicate an infinite recursion:

```
(johnnydep) ➜  johnnydep git:(circular-deps) johnnydep pkg00 --index-url=https://test.pypi.org/simple
2022-11-28 05:09:38 [info     ] init johnnydist                [johnnydep.lib] dist=pkg00 parent=None
2022-11-28 05:09:39 [info     ] init johnnydist                [johnnydep.lib] dist=pkg01 parent=pkg00
2022-11-28 05:09:39 [info     ] init johnnydist                [johnnydep.lib] dist=pkg02 parent=pkg01
2022-11-28 05:09:40 [info     ] init johnnydist                [johnnydep.lib] dist=quux parent=pkg01
2022-11-28 05:09:41 [info     ] init johnnydist                [johnnydep.lib] dist=pkg03 parent=pkg02
2022-11-28 05:09:42 [info     ] init johnnydist                [johnnydep.lib] dist=pkg01 parent=pkg03
2022-11-28 05:09:42 [info     ] pruning circular dependency    [johnnydep.lib] chain=pkg01 -> pkg02 -> pkg03 -> pkg01 dist=pkg01
name                     summary
-----------------------  ---------------------------------------------------------------------
pkg00                    default text for metadata summary
└── pkg01                default text for metadata summary
    ├── pkg02            default text for metadata summary
    │   └── pkg03        default text for metadata summary
    │       └── pkg01    default text for metadata summary
    │           └── ...  ... <circular dependency marker for pkg01 -> pkg02 -> pkg03 -> pkg01>
    └── quux             default text for metadata summary
```
