### PR TITLE
Fix serialized output formats from local .whl files

### DIFF
--- a/johnnydep/__init__.py
+++ b/johnnydep/__init__.py
@@ -1,5 +1,5 @@
 """Display dependency tree of Python distribution"""
 
-__version__ = "1.17.1"
+__version__ = "1.17.2"
 
 from johnnydep.lib import *

--- a/johnnydep/lib.py
+++ b/johnnydep/lib.py
@@ -198,7 +198,7 @@ class JohnnyDist(anytree.NodeMixin):
                 # when we're Python 3.10+ only, can use bisect.insort instead here
                 i = 0
                 for i, v in enumerate(result):
-                    if version_key > pkg_resources.parse_version(v):
+                    if version_key < pkg_resources.parse_version(v):
                         break
                 result.insert(i, local_version)
         return result

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name="johnnydep",
-    version="1.17.1",
+    version="1.17.2",
     description="Display dependency tree of Python distribution",
     long_description=open("README.md").read(),
     long_description_content_type="text/markdown",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -129,7 +129,11 @@ def add_to_index():
 @pytest.fixture
 def make_dist(tmp_path, add_to_index):
     def f(**kwargs):
-        return make_wheel(scratch_dir=str(tmp_path), callback=add_to_index, **kwargs)
+        if "callback" not in kwargs:
+            kwargs["callback"] = add_to_index
+        if "scratch_dir" not in kwargs:
+            kwargs["scratch_dir"] = str(tmp_path)
+        return make_wheel(**kwargs)
 
     return f
 

--- a/tests/test_gen.py
+++ b/tests/test_gen.py
@@ -117,9 +117,10 @@ def test_index_file_without_checksum_in_urlfragment(add_to_index, mocker):
     assert jdist.checksum == "md5=8a20520dcb1b7a729b827a2c4d75a0b6"
 
 
-def test_cant_pin():
-    whl_fname = os.path.join(here, "vanilla-0.1.2-py2.py3-none-any.whl")
-    jdist = JohnnyDist(whl_fname)
+def test_cant_pin(make_dist, mocker):
+    make_dist(name="cantpin", version="0.6")
+    jdist = JohnnyDist("cantpin")
+    mocker.patch.object(jdist, "versions_available", [])
     with pytest.raises(JohnnyError) as cm:
         jdist.pinned
     assert str(cm.value) == "Can not pin because no version available is in spec"

--- a/tests/test_lib.py
+++ b/tests/test_lib.py
@@ -517,9 +517,12 @@ def test_local_whl_pinned(make_dist):
 
 
 def test_local_whl_json(make_dist):
-    dist, dist_path, md5 = make_dist(name="loc", callback=None)
+    make_dist(name="loc", version="0.1.1")
+    dist, dist_path, md5 = make_dist(name="loc", version="0.1.2", callback=None)
+    make_dist(name="loc", version="0.1.3")
     dist = JohnnyDist(dist_path)
-    txt = dist.serialise(format="json", fields=["download_link", "checksum"]).strip()
+    fields = ["download_link", "checksum", "versions_available"]
+    txt = dist.serialise(format="json", fields=fields).strip()
     [result] = json.loads(txt)
     algo, checksum = result["checksum"].split("=")
     assert algo == "md5"
@@ -527,3 +530,4 @@ def test_local_whl_json(make_dist):
     link = result["download_link"]
     assert link.startswith("file://")
     assert link.endswith("loc-0.1.2-py2.py3-none-any.whl")
+    assert result["versions_available"] == ["0.1.1", "0.1.2", "0.1.3"]


### PR DESCRIPTION
make sure local wheel version is recognized as "available" even if not in the index. closes #105