### PR TITLE
remove dependency on pkginfo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,13 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["2.7", "3.7", "3.11"]
+        python-version:
+        - "2.7"
+        - "3.7"
+        - "3.8"
+        - "3.9"
+        - "3.10"
+        - "3.11"
 
     steps:
       - uses: "actions/checkout@v3"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["2.7", "3.11"]
+        python-version: ["2.7", "3.7", "3.11"]
 
     steps:
       - uses: "actions/checkout@v3"

--- a/johnnydep/__init__.py
+++ b/johnnydep/__init__.py
@@ -1,5 +1,5 @@
 """Display dependency tree of Python distribution"""
 
-__version__ = "1.19.0"
+__version__ = "1.20.0"
 
 from johnnydep.lib import *

--- a/johnnydep/compat.py
+++ b/johnnydep/compat.py
@@ -70,4 +70,7 @@ except ImportError:
 try:
     from zipfile import Path as zipfile_path
 except ImportError:
-    from zipfile38 import Path as zipfile_path
+    try:
+        from zipfile38 import Path as zipfile_path
+    except SyntaxError:
+        from zipfile39 import Path as zipfile_path

--- a/johnnydep/compat.py
+++ b/johnnydep/compat.py
@@ -70,4 +70,4 @@ except ImportError:
 try:
     from zipfile import Path as zipfile_path
 except ImportError:
-    from zipfile39 import Path as zipfile_path
+    from zipfile38 import Path as zipfile_path

--- a/johnnydep/compat.py
+++ b/johnnydep/compat.py
@@ -72,5 +72,5 @@ try:
 except ImportError:
     try:
         from zipfile38 import Path as zipfile_path
-    except SyntaxError:
+    except (ImportError, SyntaxError):
         from zipfile39 import Path as zipfile_path

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
         "structlog",
         "tabulate",
         "wimpy",
-        "colorama ; python_version<'3.7' or platform_system=='Windows'",  # structlog
+        "colorama ; python_version < '3.7' or platform_system == 'Windows'",  # structlog
         "cachetools",
         "oyaml",
         "toml",
@@ -30,7 +30,8 @@ setup(
         "packaging >= 17",
         "wheel >= 0.32.0",
         "importlib_metadata ; python_version < '3.10'",
-        "zipfile38 ; python_version < '3.8'",
+        "zipfile38 ; python_version < '3.8' and python_version != '2.7'",
+        "zipfile39 ; python_version == '2.7'",
     ],
     entry_points={
         "console_scripts": [

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,6 @@ setup(
         "pip",
         "packaging >= 17",
         "wheel >= 0.32.0",
-        "pkginfo >= 1.4.2",
         "importlib_metadata ; python_version < '3.7'",
         "zipfile39 ; python_version < '3.9'",
     ],

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
         "packaging >= 17",
         "wheel >= 0.32.0",
         "importlib_metadata ; python_version < '3.10'",
-        "zipfile39 ; python_version < '3.9'",
+        "zipfile38 ; python_version < '3.8'",
     ],
     entry_points={
         "console_scripts": [

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
         "pip",
         "packaging >= 17",
         "wheel >= 0.32.0",
-        "importlib_metadata ; python_version < '3.7'",
+        "importlib_metadata ; python_version < '3.10'",
         "zipfile39 ; python_version < '3.9'",
     ],
     entry_points={

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -148,7 +148,7 @@ def test_all_fields_toml_out(mocker, capsys, make_dist):
         requires = []
         required_by = []
         import_names = [ "that",]
-        console_scripts = ""
+        console_scripts = []
         homepage = "https://www.example.org/default"
         extras_available = []
         extras_requested = []

--- a/tests/test_gen.py
+++ b/tests/test_gen.py
@@ -23,7 +23,7 @@ def test_generated_metadata_from_dist_name(make_dist):
         "license": "MIT",
         "metadata_version": "2.1",
         "name": "jdtest",
-        "platforms": ["default platform"],
+        "platform": ["default platform"],
         "summary": "default text for metadata summary",
         "version": "0.1.2",
     }
@@ -44,7 +44,7 @@ def test_generated_metadata_from_dist_path(make_dist):
         "license": "MIT",
         "metadata_version": "2.1",
         "name": "jdtest",
-        "platforms": ["default platform"],
+        "platform": ["default platform"],
         "summary": "default text for metadata summary",
         "version": "0.1.2",
     }
@@ -100,7 +100,7 @@ def test_old_metadata_20(add_to_index):
         "license": "MIT",
         "metadata_version": "2.0",
         "name": "m20dist",
-        "platforms": ["default platform"],
+        "platform": ["default platform"],
         "summary": "default text for metadata summary",
         "version": "0.1.2",
     }

--- a/tests/test_lib.py
+++ b/tests/test_lib.py
@@ -490,13 +490,6 @@ def test_license_parsing_unknown(make_dist):
     assert JohnnyDist("jdtest").license == ""
 
 
-def test_metadata_cant_be_extracted(make_dist, mocker):
-    make_dist()
-    mocker.patch("pkginfo.get_metadata", return_value=None)
-    with pytest.raises(JohnnyError("failed to get metadata")):
-        JohnnyDist("jdtest")
-
-
 def test_ignore_errors(make_dist):
     make_dist(name="distA", install_requires=["distB1>=1.0"], version="0.1")
     dist = JohnnyDist("distA", ignore_errors=True)
@@ -548,4 +541,4 @@ def test_entry_points(make_dist):
     assert ep.name == "my-script"
     assert ep.group == "console_scripts"
     assert ep.value == "mypkg.mymod:foo"
-    assert dist.console_scripts == "my-script = mypkg.mymod:foo"
+    assert dist.console_scripts == ["my-script = mypkg.mymod:foo"]


### PR DESCRIPTION
this is motivated by the bug https://bugs.launchpad.net/pkginfo/+bug/1953227 not having been fixed for years, which meant johnnydep wouldn't work for tensorflow (https://github.com/wimglenn/johnnydep/issues/78)