### PR TITLE
pytest: move config to `pyproject.toml`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ pipper = "johnnydep.pipper:main"
 
 
 [tool.pytest.ini_options]
-testpaths = tests
+testpaths = "tests"
 addopts = [
     "-ra",
     "--cov=johnnydep",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,3 +31,16 @@ homepage = "https://github.com/wimglenn/johnnydep"
 [project.scripts]
 johnnydep = "johnnydep.cli:main"
 pipper = "johnnydep.pipper:main"
+
+
+[tool.pytest.ini_options]
+testpaths = tests
+addopts = [
+    "-ra",
+    "--cov=johnnydep",
+    "--cov-report=html",
+    "--cov-report=term",
+    "--no-cov-on-fail",
+    "--color=yes",
+    "--disable-socket",
+]

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,0 @@
-[pytest]
-testpaths = tests
-addopts =
-    -ra
-    --cov=johnnydep --cov-report=html --cov-report=term --no-cov-on-fail
-    --disable-socket


### PR DESCRIPTION
It is just a minor project simplification by moving `pytest` to already existing and using `pyproject.toml`