### PR TITLE
Add package size tracking features

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,138 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+doc/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+.python-version
+
+# pipenv
+Pipfile.lock
+
+# poetry
+poetry.lock
+
+# PEP 582; used by python in development mode
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyderworkspace
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# VS Code settings
+.vscode/

--- a/README.md
+++ b/README.md
@@ -35,6 +35,26 @@ A more complex tree:
             └── python-dateutil<3.0.0,>=2.1  Extensions to the standard Python datetime module
                 └── six>=1.5                 Python 2 and 3 compatibility utilities
 
+You can also view the download size and installed size of dependencies:
+
+    $ johnnydep boto3 --fields name formatted_size formatted_installed_size
+
+    name                                     formatted_size   formatted_installed_size
+    ---------------------------------------------------------------------------------------
+    boto3                                    136.8 KB         969.2 KB
+    ├── botocore<1.41.0,>=1.40.18            13.4 MB          17.5 MB
+    │   ├── jmespath<2.0.0,>=0.7.1           19.8 KB          68.0 KB
+    │   ├── python-dateutil<3.0.0,>=2.1      224.5 KB         431.2 KB
+    │   │   └── six>=1.5                     10.8 KB          37.1 KB
+    │   └── urllib3!=2.2.0,<3,>=1.25.4       126.8 KB         414.9 KB
+    ├── jmespath<2.0.0,>=0.7.1               19.8 KB          68.0 KB
+    └── s3transfer<0.14.0,>=0.13.0           83.3 KB          309.4 KB
+        └── botocore<2.0a.0,>=1.37.4         13.4 MB          17.5 MB
+            ├── jmespath<2.0.0,>=0.7.1       19.8 KB          68.0 KB
+            ├── python-dateutil<3.0.0,>=2.1  224.5 KB         431.2 KB
+            │   └── six>=1.5                 10.8 KB          37.1 KB
+            └── urllib3!=2.2.0,<3,>=1.25.4   126.8 KB         414.9 KB
+
 Johnnydep can also attempt to resolve the dependency tree:
 
     $ johnnydep ipython --output-format pinned

--- a/johnnydep/cli.py
+++ b/johnnydep/cli.py
@@ -30,6 +30,14 @@ FIELDS = {
     "version_latest_in_spec": "Best version: latest available within requirement specifier",
     "download_link": "Source or binary distribution URL",
     "checksum": "Source or binary distribution hash",
+    "size": "Size of the distribution file in bytes (compressed)",
+    "formatted_size": "Size of the distribution file formatted (compressed)",
+    "tree_size": "Cumulative file size of package and dependencies in bytes (compressed)",
+    "formatted_tree_size": "Cumulative file size of package and dependencies formatted (compressed)",
+    "installed_size": "Installed size of the distribution in bytes (uncompressed)",
+    "formatted_installed_size": "Installed size of the distribution formatted (uncompressed)",
+    "installed_tree_size": "Cumulative installed size of package and dependencies in bytes",
+    "formatted_installed_tree_size": "Cumulative installed size of package and dependencies formatted",
 }
 
 

--- a/johnnydep/lib.py
+++ b/johnnydep/lib.py
@@ -492,7 +492,12 @@ def gen_table(tree, cols):
             if d is None:
                 data[i] = ""
             elif not isinstance(d, str):
-                data[i] = ", ".join(map(str, d))
+                # Handle both iterables and single values (like integers)
+                try:
+                    data[i] = ", ".join(map(str, d))
+                except TypeError:
+                    # If d is not iterable (e.g., an integer), convert it to string
+                    data[i] = str(d)
         escaped = [rich.markup.escape(x) for x in [row0, *data]]
         table.add_row(*escaped)
     return table

--- a/tests/test_size_tracking.py
+++ b/tests/test_size_tracking.py
@@ -1,0 +1,181 @@
+"""Tests for size tracking functionality."""
+import pytest
+from johnnydep.lib import JohnnyDist, CircularMarker, _format_size
+
+
+def test_format_size():
+    """Test the _format_size function with various inputs."""
+    assert _format_size(0) == "0 B"
+    assert _format_size(512) == "512 B"
+    assert _format_size(1024) == "1.0 KB"
+    assert _format_size(1536) == "1.5 KB"
+    assert _format_size(1024 * 1024) == "1.0 MB"
+    assert _format_size(1024 * 1024 * 1024) == "1.0 GB"
+    assert _format_size(1024 * 1024 * 1024 * 1024) == "1.0 TB"
+    assert _format_size(1024 * 1024 * 1024 * 1024 * 1024) == "1024.0 TB"
+    assert _format_size(2048) == "2.0 KB"
+    assert _format_size(1024 * 512) == "512.0 KB"
+    assert _format_size(1024 * 1024 * 10) == "10.0 MB"
+
+
+def test_size_properties(make_dist):
+    """Test size and formatted_size properties."""
+    # Create a test distribution
+    dist_path = make_dist(name="sizetest", version="1.0.0")
+    dist = JohnnyDist("sizetest")
+    
+    # Test that size is populated
+    assert dist.size is not None
+    assert dist.size > 0
+    
+    # Test formatted_size
+    assert dist.formatted_size != ""
+    assert "B" in dist.formatted_size or "KB" in dist.formatted_size
+
+
+def test_installed_size_properties(make_dist):
+    """Test installed_size and formatted_installed_size properties."""
+    # Create a test distribution
+    dist_path = make_dist(name="installedsizetest", version="1.0.0")
+    dist = JohnnyDist("installedsizetest")
+    
+    # Test that installed_size is populated
+    assert dist.installed_size is not None
+    assert dist.installed_size > 0
+    
+    # Test formatted_installed_size
+    assert dist.formatted_installed_size != ""
+    assert "B" in dist.formatted_installed_size or "KB" in dist.formatted_installed_size
+
+
+def test_tree_size_with_dependencies(make_dist):
+    """Test tree_size calculation with dependencies."""
+    # Create distributions with dependencies
+    make_dist(name="dep1", version="1.0.0")
+    make_dist(name="dep2", version="1.0.0")
+    make_dist(name="main", version="1.0.0", install_requires=["dep1", "dep2"])
+    
+    dist = JohnnyDist("main")
+    
+    # Test tree_size includes dependencies
+    assert dist.tree_size is not None
+    assert dist.tree_size > dist.size
+    
+    # Test formatted_tree_size
+    assert dist.formatted_tree_size != ""
+    assert "B" in dist.formatted_tree_size or "KB" in dist.formatted_tree_size
+
+
+def test_installed_tree_size_with_dependencies(make_dist):
+    """Test installed_tree_size calculation with dependencies."""
+    # Create distributions with dependencies
+    make_dist(name="instdep1", version="1.0.0")
+    make_dist(name="instdep2", version="1.0.0")
+    make_dist(name="instmain", version="1.0.0", install_requires=["instdep1", "instdep2"])
+    
+    dist = JohnnyDist("instmain")
+    
+    # Test installed_tree_size includes dependencies
+    assert dist.installed_tree_size is not None
+    assert dist.installed_tree_size > dist.installed_size
+    
+    # Test formatted_installed_tree_size
+    assert dist.formatted_installed_tree_size != ""
+    assert "B" in dist.formatted_installed_tree_size or "KB" in dist.formatted_installed_tree_size
+
+
+def test_size_with_circular_dependencies(make_dist):
+    """Test size calculations with circular dependencies."""
+    # Create circular dependency
+    make_dist(name="circ1", version="1.0.0", install_requires=["circ2"])
+    make_dist(name="circ2", version="1.0.0", install_requires=["circ1"])
+    
+    dist = JohnnyDist("circ1")
+    
+    # Test that circular dependencies are handled
+    assert dist.tree_size is not None
+    assert dist.installed_tree_size is not None
+    assert dist.tree_size > 0
+    assert dist.installed_tree_size > 0
+
+
+def test_size_none_values(make_dist):
+    """Test handling of None values for size properties."""
+    # Create a mock distribution where we can control the size values
+    dist_path = make_dist(name="nonetest", version="1.0.0")
+    dist = JohnnyDist("nonetest")
+    
+    # Temporarily set sizes to None to test formatting
+    original_size = dist.size
+    original_installed_size = dist.installed_size
+    
+    dist.size = None
+    assert dist.formatted_size == ""
+    assert dist.tree_size is None
+    assert dist.formatted_tree_size == ""
+    
+    dist.installed_size = None
+    assert dist.formatted_installed_size == ""
+    assert dist.installed_tree_size is None
+    assert dist.formatted_installed_tree_size == ""
+    
+    # Restore original values
+    dist.size = original_size
+    dist.installed_size = original_installed_size
+
+
+def test_tree_size_excludes_duplicates(make_dist):
+    """Test that tree_size doesn't double-count shared dependencies."""
+    # Create a diamond dependency structure
+    #    main
+    #    /  \
+    #   A    B
+    #    \  /
+    #     C
+    make_dist(name="shared", version="1.0.0")
+    make_dist(name="leftdep", version="1.0.0", install_requires=["shared"])
+    make_dist(name="rightdep", version="1.0.0", install_requires=["shared"])
+    make_dist(name="diamond", version="1.0.0", install_requires=["leftdep", "rightdep"])
+    
+    dist = JohnnyDist("diamond")
+    
+    # Get individual sizes
+    shared = JohnnyDist("shared")
+    leftdep = JohnnyDist("leftdep")
+    rightdep = JohnnyDist("rightdep")
+    
+    # Tree size should not double-count the shared dependency
+    expected_max = dist.size + leftdep.size + rightdep.size + 2 * shared.size
+    assert dist.tree_size < expected_max
+    
+    # Similar check for installed_tree_size
+    expected_max_installed = dist.installed_size + leftdep.installed_size + rightdep.installed_size + 2 * shared.installed_size
+    assert dist.installed_tree_size < expected_max_installed
+
+
+def test_size_with_child_none_values(make_dist):
+    """Test tree size calculation when some children have None sizes."""
+    # This tests the branches where child.size or child.installed_size might be None
+    make_dist(name="childwithnone", version="1.0.0")
+    make_dist(name="parentofnone", version="1.0.0", install_requires=["childwithnone"])
+    
+    dist = JohnnyDist("parentofnone")
+    
+    # Temporarily set child's size to None
+    if dist.children:
+        original_size = dist.children[0].size
+        original_installed_size = dist.children[0].installed_size
+        
+        # Test with child.size = None
+        dist.children[0].size = None
+        tree_size = dist.tree_size
+        assert tree_size == dist.size  # Should only include parent's size
+        
+        # Test with child.installed_size = None  
+        dist.children[0].size = original_size
+        dist.children[0].installed_size = None
+        installed_tree_size = dist.installed_tree_size
+        assert installed_tree_size == dist.installed_size  # Should only include parent's installed size
+        
+        # Restore original values
+        dist.children[0].installed_size = original_installed_size


### PR DESCRIPTION
Really like this package - super useful for visualizing Python dist dependencies. There was just one thing missing: seeing the sizes of the dists/dependencies. Hence this PR:
                          
- Added download size (compressed wheel) tracking
- Added installed size (uncompressed) tracking
- Added cumulative tree size calculations for both metrics
- Added new CLI fields: formatted_size, formatted_installed_size,
  formatted_tree_size, formatted_installed_tree_size
- Updated README with example showing size information
- Added a `.gitignore` as my `__pycache__` files were getting tracked on git (happy to remove if need be)

This allows users to see both bandwidth requirements (download size) and disk space requirements (installed size) for dependencies.